### PR TITLE
Enhance missing package help

### DIFF
--- a/util/intelmetool/Makefile
+++ b/util/intelmetool/Makefile
@@ -74,7 +74,8 @@ pciutils:
 	@echo "$$LIBPCI_TEST" > .test.c
 	@$(CC) $(CFLAGS) .test.c -o .test $(LDFLAGS) >/dev/null 2>&1 &&	  \
 		printf "found.\n" || ( printf "not found.\n\n"; 	  \
-		printf "Please install pciutils-devel and zlib-devel.\n"; \
+		printf "Please install pciutils-devel and zlib-devel,\n"; \
+		printf "or libpci-dev.\n"; \
 		rm -f .test.c .test; exit 1)
 	@rm -rf .test.c .test .test.dSYM
 


### PR DESCRIPTION
On ubuntu 16.04 the libpci-dev package is required