### PR TITLE
Use an explicit fallthrough

### DIFF
--- a/util/cbfstool/lz4/lib/lz4frame.c
+++ b/util/cbfstool/lz4/lib/lz4frame.c
@@ -1091,7 +1091,7 @@ size_t LZ4F_decompress(LZ4F_decompressionContext_t decompressionContext,
                 dctxPtr->tmpInTarget = minFHSize;   /* minimum to attempt decode */
                 dctxPtr->dStage = dstage_storeHeader;
             }
-	    /* Falls through. */
+            __attribute__ ((fallthrough));
         case dstage_storeHeader:
             {
                 size_t sizeToCopy = dctxPtr->tmpInTarget - dctxPtr->tmpInSize;


### PR DESCRIPTION
In order to fix building with gcc7, it's better to do an explicit
fallthrough and let the compiler know that it's done on purpose.