### PR TITLE
Fixes from static analyser 

### DIFF
--- a/src/lib/imd.c
+++ b/src/lib/imd.c
@@ -156,9 +156,6 @@ static int imdr_create_empty(struct imdr *imdr, size_t root_size,
 	assert(IS_POWER_OF_2(root_size));
 	assert(IS_POWER_OF_2(entry_align));
 
-	if (!imdr->limit)
-		return -1;
-
 	/*
 	 * root_size needs to be large enough to accommodate root pointer and
 	 * root book keeping structure. The caller needs to ensure there's

--- a/src/lib/timestamp.c
+++ b/src/lib/timestamp.c
@@ -130,9 +130,6 @@ static struct timestamp_table *timestamp_table_get(void)
 	if (!timestamp_should_run())
 		return NULL;
 
-	if (ts_table != NULL)
-		return ts_table;
-
 	ts_cache = timestamp_cache_get();
 
 	if (ts_cache == NULL) {


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:
coreboot/src/lib/timestamp.c	133	warn	V547 Expression 'ts_table != NULL' is always false.
coreboot/src/lib/imd.c	159	warn	V649 There are two 'if' statements with identical conditional expressions. The first 'if' statement contains function return. This means that the second 'if' statement is senseless. Check lines: 152, 159.