### PR TITLE
Ugly hack to staple a SSTP table to the pre-generated ones QEMU sets up

### DIFF
--- a/src/arch/x86/acpi.c
+++ b/src/arch/x86/acpi.c
@@ -38,7 +38,6 @@
  */
 
 #include <console/console.h>
-#include <string.h>
 #include <arch/acpi.h>
 #include <arch/acpi_ivrs.h>
 #include <arch/acpigen.h>

--- a/src/mainboard/emulation/qemu-i440fx/fw_cfg.h
+++ b/src/mainboard/emulation/qemu-i440fx/fw_cfg.h
@@ -14,6 +14,7 @@
 #define FW_CFG_H
 #include "fw_cfg_if.h"
 
+int is_rsdp(char *);
 void fw_cfg_get(uint16_t entry, void *dst, int dstlen);
 int fw_cfg_check_file(FWCfgFile *file, const char *name);
 int fw_cfg_max_cpus(void);

--- a/src/mainboard/emulation/qemu-q35/Kconfig
+++ b/src/mainboard/emulation/qemu-q35/Kconfig
@@ -54,4 +54,8 @@ config DCACHE_BSP_STACK_SIZE
 	hex
 	default 0x4000
 
+config FMDFILE
+	string
+	default "src/mainboard/$(CONFIG_MAINBOARD_DIR)/board.fmd"
+
 endif # BOARD_EMULATION_QEMU_X86_Q35

--- a/src/mainboard/emulation/qemu-q35/board.fmd
+++ b/src/mainboard/emulation/qemu-q35/board.fmd
@@ -1,0 +1,16 @@
+# layout for firmware residing at top of 4GB address space
+# +-------------+ <-- 4GB - ROM_SIZE / start of flash
+# | unspecified |
+# +-------------+ <-- 4GB - BIOS_SIZE
+# | FMAP |
+# +-------------+ <-- 4GB - BIOS_SIZE + FMAP_SIZE
+# | CBFS |
+# +-------------+ <-- 4GB / end of flash
+FLASH@4278190080 0x1000000 {
+ BIOS@0 0x1000000 {
+  FMAP@0 0x200
+  RO_VPD@0x200 0x10000
+  RW_VPD@0x10200 0x1000
+  COREBOOT(CBFS)@0x11200
+ }
+}


### PR DESCRIPTION
This is required to allow access to the coreboot tables in SSTP, including VPD variables.