### PR TITLE
util/crossgcc/buildgcc: Support turning off color output by setting N…

### DIFF
--- a/util/crossgcc/buildgcc
+++ b/util/crossgcc/buildgcc
@@ -114,13 +114,15 @@ NASM_DIR="nasm-${NASM_VERSION}"
 
 unset MAKELEVEL MAKEFLAGS
 
-red='\033[0;31m'
-RED='\033[1;31m'
-green='\033[0;32m'
-GREEN='\033[1;32m'
-blue='\033[0;34m'
-CYAN='\033[1;36m'
-NC='\033[0m' # No Color
+if [ -z "${NO_COLOR}" ]; then
+	red='\033[0;31m'
+	RED='\033[1;31m'
+	green='\033[0;32m'
+	GREEN='\033[1;32m'
+	blue='\033[0;34m'
+	CYAN='\033[1;36m'
+	NC='\033[0m' # No Color
+fi
 
 UNAME=$(if uname | grep -iq cygwin; then echo Cygwin; else uname; fi)
 HALT_FOR_TOOLS=0


### PR DESCRIPTION
…O_COLOR

Set NO_COLOR to a non-empty value to turn off ANSI color output.
This is an informal standard supported by many CLI applications,
see https://no-color.org/ .